### PR TITLE
Refactor/main thread tests

### DIFF
--- a/solutions/devsprint-julio-fernandes-3/Targets/FinanceApp/Sources/Modules/ActivityDetails/ActivityDetailsInteractor.swift
+++ b/solutions/devsprint-julio-fernandes-3/Targets/FinanceApp/Sources/Modules/ActivityDetails/ActivityDetailsInteractor.swift
@@ -19,16 +19,15 @@ struct ActivityDetailsDTO {
 final class ActivityDetailsInteractor: ActivityDetailsInteractorProtocol {
     
     weak var presenter: ActivityDetailsInteractorDelegate?
+    let service: TempActivityDetailsServiceProtocol
     
-    private let data = ActivityDetailsDTO(
-        activityName: "Mall",
-        category: "Shopping",
-        price: 100,
-        time: Date(timeIntervalSince1970: 1653566228),
-        imageName: "bag.circle.fill"
-    )
+    init(service: TempActivityDetailsServiceProtocol) {
+        self.service = service
+    }
     
     func fetchData() {
-        presenter?.didFetch(data: data)
+        service.fetch() { [weak self] data in
+            self?.presenter?.didFetch(data: data)
+        }
     }
 }

--- a/solutions/devsprint-julio-fernandes-3/Targets/FinanceApp/Sources/Modules/ActivityDetails/ActivityDetailsPresenter.swift
+++ b/solutions/devsprint-julio-fernandes-3/Targets/FinanceApp/Sources/Modules/ActivityDetails/ActivityDetailsPresenter.swift
@@ -46,8 +46,6 @@ extension ActivityDetailsPresenter: ActivityDetailsInteractorDelegate {
     
     func didFetch(data: ActivityDetailsDTO) {
         let activityViewModel = self.parse(activityDetailsDTO: data)
-        DispatchQueue.main.async { [weak self] in
-            self?.view?.update(viewModel: activityViewModel)
-        }
+        view?.update(viewModel: activityViewModel)
     }
 }

--- a/solutions/devsprint-julio-fernandes-3/Targets/FinanceApp/Sources/Service/ActivityDetailsTempService.swift
+++ b/solutions/devsprint-julio-fernandes-3/Targets/FinanceApp/Sources/Service/ActivityDetailsTempService.swift
@@ -1,0 +1,30 @@
+//
+//  ActivityDetailsTempService.swift
+//  FinanceApp
+//
+//  Created by Mobills on 28/05/22.
+//  Copyright © 2022 tuist.io. All rights reserved.
+//
+
+import Foundation
+
+protocol TempActivityDetailsServiceProtocol {
+    func fetch(completion: @escaping (ActivityDetailsDTO) -> Void)
+}
+
+final class TempActivityDetailsService: TempActivityDetailsServiceProtocol {
+    
+    private let data = ActivityDetailsDTO(
+        activityName: "Mall",
+        category: "Shopping",
+        price: 100,
+        time: Date(timeIntervalSince1970: 1653566228),
+        imageName: "bag.circle.fill"
+    )
+    
+    func fetch(completion: @escaping (ActivityDetailsDTO) -> Void) {
+        DispatchQueue.global(qos: .background).async {
+            completion(self.data)
+        }
+    }
+}

--- a/solutions/devsprint-julio-fernandes-3/Targets/FinanceApp/Tests/Modules/ActivityDetails/ActivityDetailsPresenterTests.swift
+++ b/solutions/devsprint-julio-fernandes-3/Targets/FinanceApp/Tests/Modules/ActivityDetails/ActivityDetailsPresenterTests.swift
@@ -1,0 +1,42 @@
+//
+//  ActivityDetailsPresenterTests.swift
+//  FinanceAppTests
+//
+//  Created by Mobills on 28/05/22.
+//  Copyright © 2022 tuist.io. All rights reserved.
+//
+
+import XCTest
+@testable import FinanceApp
+
+final class ActivityDetailsPresenterTests: XCTestCase {
+
+    private let sut = ActivityDetailsPresenter()
+    private let activityDetailsPresenterDelegatSpy = ActivityDetailsPresenterDelegateSpy()
+    private let dtoDummy = ActivityDetailsDTO(
+        activityName: "", category: "",
+        price: 0,
+        time: Date(),
+        imageName: ""
+    )
+    
+    override func setUp() {
+        sut.view = activityDetailsPresenterDelegatSpy
+    }
+    
+    func test_didFetch_shouldCallViewUpdate() throws {
+        sut.didFetch(data: dtoDummy)
+        
+        XCTAssertTrue(activityDetailsPresenterDelegatSpy.didUpdateCalled)
+    }
+
+}
+
+final class ActivityDetailsPresenterDelegateSpy: ActivityDetailsPresenterDelegate {
+    
+    private(set) var didUpdateCalled = false
+    
+    func update(viewModel: ActivityDetailsViewModel) {
+        didUpdateCalled = true
+    }
+}


### PR DESCRIPTION
### Descrição simples da nova feature
Refatorei a classe ActivityDetailsPresenter para remover o DispatchQueue.main de lá, como foi proposto pelo Júlio. Criei uma classe service temporária só para representar o service e usei a abordagem de decorator para manter o service desacoplado da view. Também criei alguns testes unitários para mostrar que agora é possível testar a presenter.    
 
### Checklist:
Coloque um ```x``` nas caixas que se aplicam.
- [x] Não adiciona código duplicado
- [x] Não contém código comentado
- [x] Não contém código WIP
 
### Evidências da feature:

<img width="601" alt="Captura de Tela 2022-05-28 às 15 06 01" src="https://user-images.githubusercontent.com/40170572/170837727-1ddf9314-8709-47b1-9274-5c21cb09aa14.png">

